### PR TITLE
Authorization model

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -8,7 +8,7 @@ class SessionsController < ApplicationController
       log_in @user
       params[:session][:remember_me] == '1' ? remember(@user) : forget(@user)
       flash[:success] = "ログインしました"
-      redirect_to @user
+      redirect_back_or @user
     else
       flash.now[:danger] = 'メールアドレスまたはパスワードが正しくありません'
       render 'new'

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,4 +1,7 @@
 class UsersController < ApplicationController
+  before_action :logged_in_user, only: [:edit, :update]
+  before_action :correct_user, only: [:edit, :update]
+
   def show
     @user = User.find(params[:id])
   end
@@ -35,5 +38,22 @@ class UsersController < ApplicationController
   private
     def user_params
       params.require(:user).permit(:name, :email, :password, :password_confirmation)
+    end
+
+    #beforeアクション
+    #ログイン済みのユーザーかどうかを確認
+    def logged_in_user
+      unless logged_in?
+        store_location
+        flash[:danger] = "このページにアクセスするにはログインしてください"
+        redirect_to login_url
+      end
+    end
+
+    #正しいユーザーかどうかを確認
+    def correct_user
+      @user = User.find(params[:id])
+      flash[:danger] = "別のユーザーの情報にはアクセスできません"
+      redirect_to(root_url) unless current_user?(@user)
     end
 end

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -25,6 +25,11 @@ module SessionsHelper
     end
   end
 
+  #渡されたユーザーがログイン済みユーザーであればtrueを返す
+  def current_user?(user)
+    user == current_user
+  end
+
   #ユーザーが現在ログインしているかどうかを真偽値で返す
   def logged_in?
     !current_user.nil?
@@ -42,5 +47,16 @@ module SessionsHelper
     forget(current_user)
     session.delete(:user_id)
     @current_user = nil
+  end
+
+  #アクセスしようとしたURLを記憶しておく
+  def store_location
+    session[:forwarding_url] = request.original_url if request.get?
+  end
+
+  #記憶したURL（もしくはデフォルト値）にリダイレクト
+  def redirect_back_or(default)
+    redirect_to(session[:forwarding_url] || default)
+    session.delete(:forwarding_url)
   end
 end

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -3,6 +3,8 @@ require 'test_helper'
 class UsersControllerTest < ActionDispatch::IntegrationTest
   def setup
     @base_title = "Loca!!y"
+    @user = users(:test_user1)
+    @other_user = users(:test_user2)
   end
 
   test "should get new" do
@@ -11,4 +13,29 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     assert_select "title", "新規登録 | #{@base_title}"
   end
 
+  test "should redirect edit when not logged in" do
+    get edit_user_path(@user)
+    assert_not flash.empty?
+    assert_redirected_to login_url
+  end
+
+  test "should redirect update when not logged in" do
+    patch user_path(@user), params: {user: {name: @user.name, email: @user.email}}
+    assert_not flash.empty?
+    assert_redirected_to login_url
+  end
+
+  test "should redirect edit when logged in as wrong user" do
+    log_in_as(@other_user)
+    get edit_user_path(@user)
+    assert_not flash.empty?
+    assert_redirected_to root_url
+  end
+
+  test "should redirect update when logged in as wrong user" do
+    log_in_as(@other_user)
+    patch user_path(@user), params: {user: {name: @user.name, email: @user.email}}
+    assert_not flash.empty?
+    assert_redirected_to root_url
+  end
 end

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -1,4 +1,9 @@
 test_user1:
   name: Test User1
-  email: testuser@example.com
+  email: testuser1@example.com
+  password_digest: <%= User.digest('password') %>
+
+test_user2:
+  name: Test User2
+  email: testuser2@example.com
   password_digest: <%= User.digest('password') %>

--- a/test/integration/users_edit_test.rb
+++ b/test/integration/users_edit_test.rb
@@ -6,6 +6,7 @@ class UsersEditTest < ActionDispatch::IntegrationTest
   end
 
   test "unsuccessful edit" do
+    log_in_as(@user)
     get edit_user_path(@user)
     assert_template 'users/edit'
     patch user_path(@user), params: {user: {
@@ -18,9 +19,11 @@ class UsersEditTest < ActionDispatch::IntegrationTest
     assert_select 'div.alert'
   end
 
-  test "successful edit" do
+  test "successful edit with friendly forwarding" do
     get edit_user_path(@user)
-    assert_template 'users/edit'
+    log_in_as(@user)
+    assert_redirected_to edit_user_url(@user)
+    assert_nil session[:forwarding_url]
     name = "Test Edit"
     email = "test@edit.com"
     patch user_path(@user), params: {user: {


### PR DESCRIPTION
認可モデルを形成するために、ログイン済み・適切なユーザーによるログインでのアクセス制限を実装しました。そのためにログインユーザーを確かめるメソッドやフレンドリーフォワーディングを実行するメソッドを作成しました。