### PR TITLE
Implement display last login date

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -57,7 +57,6 @@ img.img-rounded {
 }
 
 img.img-size40 {
-  border: solid 1.5px $border-gray;
   width: 4rem;
 }
 

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -7,6 +7,7 @@ class SessionsController < ApplicationController
     if @user && @user.authenticate(params[:session][:password])
       if @user.activated?
         log_in @user
+        @user.update_attribute(:login_at, Time.zone.now)
         params[:session][:remember_me] == '1' ? remember(@user) : forget(@user)
         flash[:success] = "ログインしました"
         redirect_back_or @user

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -58,7 +58,7 @@ class User < ApplicationRecord
 
   #アカウントを有効にする
   def activate
-    update_columns(activated: true, activated_at: Time.zone.now)
+    update_columns(activated: true, activated_at: Time.zone.now, login_at: Time.zone.now)
   end
 
   #有効化リンクのついたメールを送信する

--- a/app/views/users/_user.html.erb
+++ b/app/views/users/_user.html.erb
@@ -5,7 +5,7 @@
   </td>
   <td class="align-middle"><%= link_to user.name, user %></td>
   <td class="align-middle"><%= user.email %></td>
-  <td class="align-middle">yesterday</td>
+  <td class="align-middle"><%= user.login_at.strftime('%Y/%m/%d %H:%M:%S') %></td>
   <td class="align-middle">
     <% if current_user.admin? && !current_user?(user) %>
       <%= link_to "このユーザーを削除", user, method: :delete, class: "delete-link", data: {confirm: "本当に削除してよろしいですか？"} %>

--- a/db/migrate/20200222110837_add_login_at_to_users.rb
+++ b/db/migrate/20200222110837_add_login_at_to_users.rb
@@ -1,0 +1,5 @@
+class AddLoginAtToUsers < ActiveRecord::Migration[5.1]
+  def change
+    add_column :users, :login_at, :timestamp
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200219090910) do
+ActiveRecord::Schema.define(version: 20200222110837) do
 
   create_table "contacts", force: :cascade do |t|
     t.datetime "created_at", null: false
@@ -51,6 +51,7 @@ ActiveRecord::Schema.define(version: 20200219090910) do
     t.string "reset_digest"
     t.datetime "reset_sent_at"
     t.string "image"
+    t.datetime "login_at"
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,7 +6,8 @@ User.create!(
             password_confirmation: "foobar",
             admin: true,
             activated: true,
-            activated_at: Time.zone.now
+            activated_at: Time.zone.now,
+            login_at: Time.zone.now
             )
 
 99.times do |n|
@@ -19,7 +20,8 @@ User.create!(
               password: password,
               password_confirmation: password,
               activated: true,
-              activated_at: Time.zone.now
+              activated_at: Time.zone.now,
+              login_at: rand(1..99).hours.ago
               )
 end
 

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -8,6 +8,7 @@ test_user1:
   activated: true,
   activated_at: <%= Time.zone.now %>
   image: <%= file_path.join('images', 'default.jpg') %>
+  login_at: <%= Time.zone.now %>
 
 test_user2:
   name: Test User2
@@ -16,6 +17,7 @@ test_user2:
   activated: true,
   activated_at: <%= Time.zone.now %>
   image: <%= file_path.join('images', 'default.jpg') %>
+  login_at: <%= Time.zone.now %>
 
 test_user3:
   name: Test User3
@@ -24,6 +26,7 @@ test_user3:
   activated: true,
   activated_at: <%= Time.zone.now %>
   image: <%= file_path.join('images', 'default.jpg') %>
+  login_at: <%= Time.zone.now %>
 
 test_user4:
   name: Test User4
@@ -32,6 +35,7 @@ test_user4:
   activated: true,
   activated_at: <%= Time.zone.now %>
   image: <%= file_path.join('images', 'default.jpg') %>
+  login_at: <%= Time.zone.now %>
 
 <% 30.times do |n| %>
 user_<%= n %>:
@@ -40,4 +44,5 @@ user_<%= n %>:
   password_digest: <%= User.digest('password') %>
   activated: true,
   activated_at: <%= Time.zone.now %>
+  login_at: <%= Time.zone.now %>
 <% end %>

--- a/test/integration/users_index_test.rb
+++ b/test/integration/users_index_test.rb
@@ -13,6 +13,8 @@ class UsersIndexTest < ActionDispatch::IntegrationTest
     first_page_of_users = User.where(activated: true).paginate(page: 1)
     first_page_of_users.each do |user|
       assert_select 'a[href=?]', user_path(user), text: user.name
+      assert_match user.email, response.body
+      assert_match user.login_at, response.body
       unless user == @admin
         assert_select 'a[href=?]', user_path(user), text: 'このユーザーを削除'
       end


### PR DESCRIPTION
各ユーザーの最終ログイン日時をユーザー一覧ページで表示されるように実装しました。ログイン日時はユーザーがアクティベーションされた時とログインされた時に更新されるようにしました。また、既存のユーザー一覧ページの統合テストに今回実装させた情報が正しく表示されているかを検証しています。